### PR TITLE
chore(ui): Update scroll indicator breakpoint and adjust user details grid layout for responsive design

### DIFF
--- a/src/components/scroll-indicator/scroll-indicator.module.scss
+++ b/src/components/scroll-indicator/scroll-indicator.module.scss
@@ -8,7 +8,7 @@
   right: calc(var(--space-md) * -2);
   opacity: 1;
 
-  @include breakpoints.respond-below('md') {
+  @include breakpoints.respond-below('lg') {
     display: none;
   }
 }

--- a/src/components/user-details/user-details.module.scss
+++ b/src/components/user-details/user-details.module.scss
@@ -35,7 +35,11 @@
 }
 
 .infoGrid {
-  columns: 2;
+  columns: 1;
+
+  @include breakpoints.respond-above('sm') {
+    columns: 2;
+  }
 }
 
 .infoItem {


### PR DESCRIPTION
- Changed the breakpoint for hiding the scroll indicator from 'md' to 'lg'.
- Modified the user details grid to use 1 column by default, switching to 2 columns above the 'sm' breakpoint.